### PR TITLE
Remove R version check

### DIFF
--- a/R/packagemetrics.R
+++ b/R/packagemetrics.R
@@ -8,4 +8,4 @@
 #' @keywords internal
 NULL
 ## quiets concerns of R CMD check re: the .'s that appear in pipelines
-if(getRversion() >= "2.15.1")  utils::globalVariables(c("."))
+utils::globalVariables(c("."))


### PR DESCRIPTION
The Description file states that R >= 3.4, therefore the version check is redundant.