### PR TITLE
Detect spaces between urls

### DIFF
--- a/R/getGitHub.R
+++ b/R/getGitHub.R
@@ -19,11 +19,11 @@ getGitHub <- function(packages){
     dplyr::filter(package %in% packages) %>%
     dplyr::select(package, url, bugreports)
 
-
   url <- cran_urls$url[2] #temp
   find_github <- function(url){
     url <- gsub("\n", ",", url)
-    url <- gsub(" ", "", url)
+    url <- gsub("^ | $", "", url)
+    url <- gsub(" ", ",", url)
     url <- gsub("https", "http", url)
     url <- gsub("http", "https", url)
     url_list <- stringr::str_split(url, ",")[[1]]


### PR DESCRIPTION
lme4 (https://cran.r-project.org/web/packages/lme4/index.html) currently fails due to a space between urls. The "github" url ends up being
```
https://github.com/lme4/lme4/http://lme4.r-forge.r-project.org/
```