### PR TITLE
Always return number of contributors

### DIFF
--- a/R/scrape_github_url.R
+++ b/R/scrape_github_url.R
@@ -119,9 +119,12 @@ get_last_issue_closed <- function(repo_url){
 }
 
 get_num_contributors <- function(page_html){
-  page_html %>%
+  no_of_contributors <- page_html %>%
     rvest::html_nodes(".numbers-summary a") %>%
     rvest::html_text() %>% stringr::str_match_all(" [0-9]+") %>% unlist() %>%
-    dplyr::last() %>% as.numeric() %>%
-    data.frame(contributors=.)
+    dplyr::last() %>% as.numeric()
+  
+  if(length(no_of_contributors) == 0L) no_of_contributors = NA
+  
+  data.frame(contributors = no_of_contributors)
 }


### PR DESCRIPTION
Not all packages return the base GitHub url, e.g. the URL for https://cran.r-project.org/web/packages/tsDyn/index.html is http://github.com/MatthieuStigler/tsDyn/wiki

This causes `get_num_contributors()` to fail.

You could recover the canonical URL, i.e. remove `wiki` but this would be wrong in a few cases where more than one package lives in the same github repo. Options:

 * Return 1 
 * Return NA (proposed PR)