### PR TITLE
Fix vignette indicator

### DIFF
--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -26,7 +26,7 @@ cran_metrics <- function(package_name) {
     dplyr::funs(count = count_packages), depends:reverse_depends) %>%
   dplyr::mutate(
     tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse="|")), TRUE, FALSE),
-    has_vignette_build = ifelse(is.na(vignettebuilder), TRUE, FALSE),
+    has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),
     has_tests = ifelse(stringr::str_detect(suggests, "testthat|RUnit"), TRUE, FALSE),
     has_tests = ifelse(is.na(has_tests), FALSE, has_tests),
     reverse_count = ifelse(is.na(reverse_imports_count), 0, reverse_imports_count) + ifelse(is.na(reverse_depends_count), 0, reverse_depends_count)

--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -1,7 +1,7 @@
 #' @title Get CRAN-related metrics for a package.
 #'
 #' @description
-#' Searches CRAN database to pull information like depnedencies, reverse dependencies, etc.
+#' Searches CRAN database to pull information like dependencies, reverse dependencies, etc.
 #'
 #' @param package_name name of CRAN package - case-sensitive.
 #'
@@ -25,7 +25,7 @@ cran_metrics <- function(package_name) {
   dplyr::mutate_each(
     dplyr::funs(count = count_packages), depends:reverse_depends) %>%
   dplyr::mutate(
-    tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse="|")), TRUE, FALSE),
+    tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse = "|")), TRUE, FALSE),
     has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),
     has_tests = ifelse(stringr::str_detect(suggests, "testthat|RUnit"), TRUE, FALSE),
     has_tests = ifelse(is.na(has_tests), FALSE, has_tests),


### PR DESCRIPTION
Hello, 

Really like the package - great work!

In `cran_metrics()`, the `has_vignette_build` field is currently assigned `TRUE` if the field is `NA`. But if it's `NA`, that means that there is not a vignette, so the `ifelse()` return values are switched.

This PR fixes that, along with a typo in the `cran_metrics()` documentation.

Best,
Trey