### PR TITLE
Handle non-cran packages

### DIFF
--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -18,9 +18,12 @@ cran_metrics <- function(package_name, forget = FALSE) {
                    "stringr",   "tibble",    "rvest",     "tidyr",     "xml2",      "tidyverse")
   cran = get_cran(forget)
 
-  if (!(package_name %in% cran$package))
-    stop(sprintf("Package %s not in CRAN. Only supply packages that exists in CRAN",
-         package_name))
+  if (!(package_name %in% cran$package)) {
+    return(tibble::tibble(package = package_name,
+                   published = NA, title = NA, depends_count = NA,suggests_count = NA,
+                   tidyverse_happy = NA, has_vignette_build = NA, has_tests = NA,
+                   reverse_count = NA, dl_last_month = NA))
+  }
 
   cran %>%
   dplyr::filter(package %in% package_name) %>%

--- a/R/getGitHub.R
+++ b/R/getGitHub.R
@@ -13,10 +13,7 @@
 
 getGitHub <- function(packages, forget = FALSE){
 
-  inCran(packages, forget)
-  # Don't need forget parameter, since forget =TRUE would have
-  # been triggered in inCran
-  cran_urls <- get_cran() %>%
+  cran_urls <- get_cran(forget = forget) %>%
     dplyr::filter(package %in% packages) %>%
     dplyr::select(package, url, bugreports)
 
@@ -45,10 +42,10 @@ getGitHub <- function(packages, forget = FALSE){
 
 }
 
-inCran <- function(package, forget = FALSE){
+in_cran <- function(package, forget = FALSE){
   cran = get_cran(forget)
   #stopifnot(package %in% cran$package)
-  if(! (package %in% cran$package )) stop("Package ",  package, " not in CRAN.  Only supply packages that exists in CRAN")
+  package %in% cran$package
 }
 
 

--- a/R/get_cran.R
+++ b/R/get_cran.R
@@ -20,8 +20,6 @@ get_memoise_cran <- memoise::memoise({
   }}
 )
 
-
-
 #' Get CRAN Packages
 #'
 #' Returns a tibble containing the current CRAN pacakges.

--- a/R/scrape_github_url.R
+++ b/R/scrape_github_url.R
@@ -16,12 +16,15 @@
 
 
 scrape_github_package_page <- function(package_name){
-  gh_info <- getGitHub(package_name)
-  repo_url <- gh_info$github_url
-  if(is.na(repo_url) || http_status(GET(repo_url))$category != "Success"){
-    return(data.frame(package = package_name,
-                      ci = "Not on GitHub",
-                      test_coverage = "Not on GitHub",
+  if(in_cran(package_name)) {
+    gh_info <- getGitHub(package_name)
+    repo_url <- gh_info$github_url
+  }
+
+  if(!in_cran(package_name) || is.na(repo_url) || http_status(GET(repo_url))$category != "Success"){
+    return(tibble::tibble(package = package_name,
+                      ci = NA,
+                      test_coverage = NA,
                       forks = NA,
                       stars = NA,
                       watchers = NA,


### PR DESCRIPTION
If a package doesn't exist in CRAN, just return NAs - don't break.

Fixes #43 

---
```
package_list_metrics(c("dplyr", "dplyr2"))
```
now returns 
```
 package  published                          title depends_count suggests_count
1   dplyr 2018-05-19 A Grammar of Data Manipulation             1             19
2  dplyr2       <NA>                           <NA>            NA             NA          NA
<snip>
```