### PR TITLE
update to newer tidyverse functions, fix github scraping bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,12 +29,13 @@ Imports:
     tibble,
     formattable,
     memoise,
-    httr
+    httr,
+    tidyverse
 Remotes: lshep/stackr
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr

--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -32,7 +32,7 @@ cran_metrics <- function(package_name, forget = FALSE) {
          reverse_imports, reverse_depends,
          vignettebuilder, published, title
          ) %>%
-  dplyr::mutate_at(dplyr::vars(depends:reverse_depends), dplyr::funs(count = count_packages)) %>%
+  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages)) %>%
   dplyr::mutate(
     tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse = "|")), TRUE, FALSE),
     has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),

--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -13,9 +13,7 @@
 #' cran_metrics("dplyr")
 
 cran_metrics <- function(package_name, forget = FALSE) {
-  tv_packages <- c("broom",     "dplyr",     "forcats",   "ggplot2",   "haven",     "httr",      "hms",
-                   "jsonlite",  "lubridate", "magrittr",  "modelr",    "purrr",     "readr",     "readxl",
-                   "stringr",   "tibble",    "rvest",     "tidyr",     "xml2",      "tidyverse")
+  tv_packages <- tidyverse::tidyverse_packages(include_self = TRUE)
   cran = get_cran(forget)
 
   if (!(package_name %in% cran$package)) {
@@ -32,7 +30,7 @@ cran_metrics <- function(package_name, forget = FALSE) {
          reverse_imports, reverse_depends,
          vignettebuilder, published, title
          ) %>%
-  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages.names = "{col}_count")) %>%
+  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages, .names = "{col}_count")) %>%
   dplyr::mutate(
     tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse = "|")), TRUE, FALSE),
     has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),

--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -32,7 +32,7 @@ cran_metrics <- function(package_name, forget = FALSE) {
          reverse_imports, reverse_depends,
          vignettebuilder, published, title
          ) %>%
-  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages.names = "{col}_count"))) %>%
+  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages.names = "{col}_count")) %>%
   dplyr::mutate(
     tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse = "|")), TRUE, FALSE),
     has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),

--- a/R/cran_metrics.R
+++ b/R/cran_metrics.R
@@ -32,7 +32,7 @@ cran_metrics <- function(package_name, forget = FALSE) {
          reverse_imports, reverse_depends,
          vignettebuilder, published, title
          ) %>%
-  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages)) %>%
+  dplyr::mutate(dplyr::across(depends:reverse_depends, count_packages.names = "{col}_count"))) %>%
   dplyr::mutate(
     tidyverse_happy = ifelse(stringr::str_detect(imports, paste(tv_packages, collapse = "|")), TRUE, FALSE),
     has_vignette_build = ifelse(is.na(vignettebuilder), FALSE, TRUE),

--- a/R/get_cran.R
+++ b/R/get_cran.R
@@ -5,7 +5,7 @@ get_memoise_cran <- memoise::memoise({
     cran <- cran[, -dplyr::first(which(names(cran) == "MD5sum"))]
 
     # make it a tibble
-    cran <- dplyr::tbl_df(cran)
+    cran <- tibble::as_tibble(cran)
 
     if (packageVersion("janitor") > "0.3.1") {
       cran <- cran %>%
@@ -14,7 +14,7 @@ get_memoise_cran <- memoise::memoise({
     } else {
       cran <- cran %>%
         janitor::clean_names() %>%
-        janitor::remove_empty_cols()
+        janitor::remove_empty("cols")
     }
     cran
   }}

--- a/R/scrape_github_url.R
+++ b/R/scrape_github_url.R
@@ -85,7 +85,9 @@ get_last_commit <- function(page_html){
   dateLastCommit <- page_html %>%
     rvest::html_nodes("relative-time") %>%
     purrr::map(xml2::xml_attrs) %>%
-    purrr::map_df(~as.list(.))
+    purrr::map_df(~as.list(.)) %>%
+    dplyr::slice(1) # as of Aug 2020, first value is most recent commit, second is latest release
+
 
   if(nrow(dateLastCommit) == 0){
     # dateLastCommit <- dplyr::tibble(last_commit = NA_character_)


### PR DESCRIPTION
- closes #50 
- uses tidyverse::tidyverse_packages() to ID tidyverse affiliations, which adds tidyverse dependency
- fixes bug in GitHub scraping that was causing duplicated rows